### PR TITLE
remove duplicated values in labels; fixed issue #79

### DIFF
--- a/R/read_dhs_flat.R
+++ b/R/read_dhs_flat.R
@@ -78,6 +78,9 @@ parse_dcf <- function(dcf, all_lower=TRUE) {
   values <- Map("names<-", values, labels)
   values <- lapply(values, function(x) x[!is.na(x) & nzchar(names(x))])
 
+  ## remove duplicate values from labels
+  values <- lapply(values, function(x) x[!duplicated(x)])
+
   dcf$labels[hasvs] <- values
 
   ## Expand dictionary for multiple occurences


### PR DESCRIPTION
fix #79 

This arose as an issue due to change in haven 2.1.0 from this commit: https://github.com/tidyverse/haven/commit/ac15324b

The issue I found was that in some cases the same value was duplicated in the value labels parsed from the DCF file. For example in the "MVIR71FL.ZIP" dataset, for variable `v128` the code `96` was repeated twice:
```
Browse[3]> values[[49]]
                 NATURAL                 No walls              RUDIMENTARY Thin plywood/wood sticks        Thatch and sticks              Reused wood 
                      10                       11                       20                       24                       25                       26 
                FINISHED                   Cement   Stone with lime/cement                   Bricks                    Other                    Other 
                      30                       31                       32                       33                       96                       96 
   Not a dejure resident                  Missing 
                      97                       99 
```
