### PR TITLE
remove duplicated values in labels for parse_sps(); fixed issue #79

### DIFF
--- a/R/read_dhs_flat.R
+++ b/R/read_dhs_flat.R
@@ -194,6 +194,9 @@ parse_sps <- function(sps, all_lower=TRUE) {
   valnum <- lapply(valnum, "storage.mode<-", "integer")
   values[!is.na(numericvar) & numericvar] <- valnum
 
+  ## remove duplicate values from labels
+  values <- lapply(values, function(x) x[!duplicated(x)])
+  
   dct$labels <- values[dct$name]
 
   return(dct)


### PR DESCRIPTION
The previous commit c728c4d only addressed this for parse_dcf().  This addressed the issue for datasets parsed with parse_sps().

fix #79 (again): `get_datasets("mzir41fl.zip")` and `get_datasets("ZMIR31FL.ZIP")` now work.

