### PR TITLE
change default download_boundaries(..., method = "sf")

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Suggests:
     microbenchmark,
     sf
 License: MIT + file LICENSE
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Language: en-GB
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Suggests:
     microbenchmark,
     sf
 License: MIT + file LICENSE
-RoxygenNote: 7.0.0
+RoxygenNote: 7.0.2
 VignetteBuilder: knitr
 Language: en-GB
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## rdhs 0.7.1
+
+* Use `"sf"` as default download method for `download_boundaries(..., method = "sf")`.
+
 ## rdhs 0.7.0
 
 * Add CITATION info.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 ## rdhs 0.7.1
 
 * Use `"sf"` as default download method for `download_boundaries(..., method = "sf")`.
+* Add arguments `quiet_download` and `quiet_parse = TRUE` to 
+  `download_boundaries()`. `quiet_download` (default `FALSE`) controls `download.file()` 
+  messages. `quiet_parse` (default `TRUE`) controls messages from `sf::st_read()` when
+  `method = "sf"`.
 
 ## rdhs 0.7.0
 

--- a/R/shapes.R
+++ b/R/shapes.R
@@ -18,6 +18,10 @@
 #'   Default = "sf", which uses \code{sf::st_read}. Currenlty, you can also
 #'   specify "rgdal", which reads the file using rgdal::readOGR.
 #'   To just return the file paths for the files use method = "zip".
+#' @param quiet_parse Whether to download file quietly. Passed to
+#'   [`download_file()`]. Default is `FALSE`.
+#' @param quiet_parse Whether to read boundaries dataset quietly. Applies to
+#'   `method = "sf"`. Default is `TRUE`.
 #'
 #' @details Downloads the spatial boundaries from the DHS spatial repository,
 #'   which can be found at \url{https://spatialdata.dhsprogram.com/home/}.
@@ -42,7 +46,9 @@
 download_boundaries <- function(surveyNum=NULL,
                                 surveyId = NULL,
                                 countryId = NULL,
-                                method = "sf"){
+                                method = "sf",
+                                quiet_download = FALSE,
+                                quiet_parse = TRUE){
 
   # helper funcs
   build_final_url <- function(jobId) {
@@ -109,7 +115,7 @@ download_boundaries <- function(surveyNum=NULL,
 
   # download the shape file and read it in
   tf2 <- tempfile()
-  file <- download.file(url, tf2)
+  file <- download.file(url, tf2, quiet = quiet_download)
   unzipped_files <- suppressWarnings(unzip(tf2, exdir = tempfile()))
   file <- grep("dbf", unzipped_files, value=TRUE)
 
@@ -127,7 +133,7 @@ download_boundaries <- function(surveyNum=NULL,
 
     # here if we want to add more read in options
     if(method == "sf") {
-      res <- lapply(file, sf::st_read)
+      res <- lapply(file, sf::st_read, quiet = quiet_parse)
       names(res) <- vapply(file,
                            function(x) { sf::st_layers(x)$name },
                            character(1))

--- a/R/shapes.R
+++ b/R/shapes.R
@@ -15,8 +15,8 @@
 #'   being downloaded. Default = NULL, which will cause the countrycode to be
 #'   looked up from the API.
 #' @param method Character for how the downloaded shape file is read in.
-#'   Default = "rdgal", which reads the file using rgdal::readOGR. At current
-#'   you can also specify sf, which uses \code{sf::st_read}.
+#'   Default = "sf", which uses \code{sf::st_read}. Currenlty, you can also
+#'   specify "rgdal", which reads the file using rgdal::readOGR.
 #'   To just return the file paths for the files use method = "zip".
 #'
 #' @details Downloads the spatial boundaries from the DHS spatial repository,
@@ -34,15 +34,15 @@
 #'  # using the surveyId and no countryID
 #'  res <- download_boundaries(surveyId = "AF2010OTH")
 #'
-#'  # using sf
-#'  res <- download_boundaries(surveyNum = 471, countryId = "AF", method = "sf")
+#'  # using rgdal
+#'  res <- download_boundaries(surveyNum = 471, countryId = "AF", method = "rgdal")
 #'  }
 
 
 download_boundaries <- function(surveyNum=NULL,
                                 surveyId = NULL,
                                 countryId = NULL,
-                                method = "rgdal"){
+                                method = "sf"){
 
   # helper funcs
   build_final_url <- function(jobId) {

--- a/man/dhs_gps_data_format.Rd
+++ b/man/dhs_gps_data_format.Rd
@@ -4,14 +4,16 @@
 \name{dhs_gps_data_format}
 \alias{dhs_gps_data_format}
 \title{DHS GPS Data Format}
-\format{A dataframe of 20 observations of 3 variables:
+\format{
+A dataframe of 20 observations of 3 variables:
 
 \code{dhs_gps_data_format}: A dataframe of GPS data descriptions.
 \itemize{
       \item{"Name"}
       \item{"Type"}
       \item{"Description"}
-      }}
+      }
+}
 \usage{
 data(dhs_gps_data_format)
 }

--- a/man/download_boundaries.Rd
+++ b/man/download_boundaries.Rd
@@ -8,7 +8,9 @@ download_boundaries(
   surveyNum = NULL,
   surveyId = NULL,
   countryId = NULL,
-  method = "sf"
+  method = "sf",
+  quiet_download = FALSE,
+  quiet_parse = TRUE
 )
 }
 \arguments{
@@ -32,6 +34,9 @@ looked up from the API.}
 Default = "sf", which uses \code{sf::st_read}. Currenlty, you can also
 specify "rgdal", which reads the file using rgdal::readOGR.
 To just return the file paths for the files use method = "zip".}
+
+\item{quiet_parse}{Whether to read boundaries dataset quietly. Applies to
+`method = "sf"`. Default is `TRUE`.}
 }
 \value{
 Returns either the spatial file as a "SpatialPolygonsDataFrame" or

--- a/man/download_boundaries.Rd
+++ b/man/download_boundaries.Rd
@@ -8,7 +8,7 @@ download_boundaries(
   surveyNum = NULL,
   surveyId = NULL,
   countryId = NULL,
-  method = "rgdal"
+  method = "sf"
 )
 }
 \arguments{
@@ -29,8 +29,8 @@ being downloaded. Default = NULL, which will cause the countrycode to be
 looked up from the API.}
 
 \item{method}{Character for how the downloaded shape file is read in.
-Default = "rdgal", which reads the file using rgdal::readOGR. At current
-you can also specify sf, which uses \code{sf::st_read}.
+Default = "sf", which uses \code{sf::st_read}. Currenlty, you can also
+specify "rgdal", which reads the file using rgdal::readOGR.
 To just return the file paths for the files use method = "zip".}
 }
 \value{
@@ -52,7 +52,7 @@ Downloads the spatial boundaries from the DHS spatial repository,
  # using the surveyId and no countryID
  res <- download_boundaries(surveyId = "AF2010OTH")
 
- # using sf
- res <- download_boundaries(surveyNum = 471, countryId = "AF", method = "sf")
+ # using rgdal
+ res <- download_boundaries(surveyNum = 471, countryId = "AF", method = "rgdal")
  }
 }

--- a/man/model_datasets.Rd
+++ b/man/model_datasets.Rd
@@ -4,7 +4,8 @@
 \name{model_datasets}
 \alias{model_datasets}
 \title{DHS model datasets}
-\format{A dataframe of 36 observations of 14 variables:
+\format{
+A dataframe of 36 observations of 14 variables:
 
 \code{model_datasets}: A dataframe of model datasets
 \itemize{
@@ -22,7 +23,8 @@
       \item{"FileName"}
       \item{"CountryName"}
       \item{"URLS"}
-      }}
+      }
+}
 \usage{
 data(model_datasets)
 }

--- a/tests/testthat/test_spatial_boundaries.R
+++ b/tests/testthat/test_spatial_boundaries.R
@@ -15,7 +15,8 @@ test_that("Spatial Boundaries Download", {
    # using the surveyNum
    res <- download_boundaries(surveyNum = 471, countryId = "AF")
    expect_true(res$sdr_subnational_boundaries$ISO[1] == "AF")
-
+   expect_is(res$sdr_subnational_boundaries, "sf")
+  
    # using the surveyId and no countryID
    res <- download_boundaries(surveyId = "AF2010OTH")
    expect_true(length(res) == 2)
@@ -24,6 +25,19 @@ test_that("Spatial Boundaries Download", {
    # using sf
    res <- download_boundaries(surveyNum = 471, countryId = "AF", method = "sf")
    expect_true(res$sdr_subnational_boundaries$ISO[1] == "AF")
+   expect_is(res$sdr_subnational_boundaries, "sf")
+
+   # using rgdal
+   res <- download_boundaries(surveyNum = 471, countryId = "AF", method = "rgdal")
+   expect_true(res$sdr_subnational_boundaries$ISO[1] == "AF")
+   expect_is(res$sdr_subnational_boundaries, "SpatialPolygonsDataFrame")
+
+   # unsupported method
+    expect_message(res <- download_boundaries(surveyNum = 471, countryId = "AF",
+                                              method = "jibberish"),
+                   "Provided method not found.")
+    expect_is(res, "character")
+    expect_true(any(grepl("\\.shp$", res)))
 
 })
 


### PR DESCRIPTION
As discussed `sf` is just better. I extended the tests for `download_boundaries()` slightly to test the `method = ` argument options.

_Edit: 20 November:_ I've further added to this PR arguments `quiet_download` (default `= FALSE`) and `quiet_parse` (default = `TRUE`) to control messages from `download.file()` and `sf::st_read()`.

Thanks for your consideration.