### PR TITLE
Remove dhs_dataset class from downloaded dataset object.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rdhs
 Type: Package
 Title: API Client and Dataset Management for the Demographic and Health Survey (DHS) Data
-Version: 0.7.0
+Version: 0.7.1
 Authors@R: 
     c(person(given = "OJ",
              family = "Watson",
@@ -54,7 +54,7 @@ Suggests:
     microbenchmark,
     sf
 License: MIT + file LICENSE
-RoxygenNote: 7.0.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Language: en-GB
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## rdhs 0.7.1
+
+* Remove class `"dhs_dataset"` from downloaded micro data sets. This class is not 
+  anywhere and it creates an error for dplyr_v1.0. 
+  
+  Cached datasets will need to be re-downloaded after updating to clear the 
+  dhs_dataset clas.
+  
 ## rdhs 0.7.0
 
 * Add CITATION info.

--- a/R/api_endpoints.R
+++ b/R/api_endpoints.R
@@ -24,7 +24,7 @@
 #'   which a specific set of indicators is present, add
 #'   `selectSurveys="byIndicator"` in conjunction with Indicator IDs, Country
 #'   Code, and/or Survey Type instead
-#'   of using `selectSurveys="latest"`.
+#'   of using `selectSurveys="latest"`
 #' @param surveyYear Specify a comma separated list of survey years to
 #'   filter by.
 #' @param surveyYearStart Specify a range of Survey Years to filter Data on.

--- a/R/rbind_labelled.R
+++ b/R/rbind_labelled.R
@@ -70,7 +70,7 @@ rbind_labelled <- function(..., labels=NULL, warn=TRUE) {
     dfs <- dfs[[1]]
   }
 
-  # what kind of dataset is it we are working with
+  # what kind of dataset are working with
   type <- dataset_label_type(dfs[[1]], stop = FALSE)
 
   # if the data has names let's grab that and append it
@@ -81,7 +81,7 @@ rbind_labelled <- function(..., labels=NULL, warn=TRUE) {
     }
   }
 
-  # if its a foregin or reformatted dataset list then skip over the labelling
+  # if its a foreign or reformatted dataset list then skip over the labelling
   if (type == "labelled") {
 
     ## Ensure same column ordering for all dfs
@@ -170,12 +170,13 @@ rbind_labelled <- function(..., labels=NULL, warn=TRUE) {
     }
 
     ## rbind data frames
-    df <- do.call(rbind, dfs)
+    dfs_raw <- lapply(dfs, haven::zap_labels)
+    df <- do.call(rbind, dfs_raw)
 
     ## Convert concatenated variables back to labelled
     df[catvar] <- lapply(df[catvar], factor)
 
-    # match on haven package version
+    ## match on haven package version
     if (packageVersion("haven") > "1.1.2") {
 
       ## Get the label attribute

--- a/R/read_datasets.R
+++ b/R/read_datasets.R
@@ -188,8 +188,6 @@ factor_format <- function(res, reformat=FALSE, all_lower=TRUE) {
                                            description_table$description)
   }
 
-  class(res) <- c(class(res), "dhs_dataset")
-
   return(list("dataset" = res, "variable_names" = description_table))
 }
 

--- a/R/read_datasets.R
+++ b/R/read_datasets.R
@@ -173,8 +173,7 @@ factor_format <- function(res, reformat=FALSE, all_lower=TRUE) {
       pos <- match(names(lab[i]), names(res))
       lab_match <- which(!is.na(match(res[[pos]], lab[[i]])))
       if (length(lab_match) > 0) {
-        res[[pos]][lab_match] <- names(lab[[i]])[match(res[[pos]][lab_match],
-                                                       lab[[i]])]
+        res[[pos]] <- haven::as_factor(res[[pos]])
       }
     }
 

--- a/man/dhs_data.Rd
+++ b/man/dhs_data.Rd
@@ -49,7 +49,7 @@ To filter your API Indicator Data call to return the latest survey data in
 which a specific set of indicators is present, add
 `selectSurveys="byIndicator"` in conjunction with Indicator IDs, Country
 Code, and/or Survey Type instead
-of using `selectSurveys="latest"`.}
+of using `selectSurveys="latest"`}
 
 \item{surveyYear}{Specify a comma separated list of survey years to
 filter by.}

--- a/man/dhs_gps_data_format.Rd
+++ b/man/dhs_gps_data_format.Rd
@@ -4,14 +4,16 @@
 \name{dhs_gps_data_format}
 \alias{dhs_gps_data_format}
 \title{DHS GPS Data Format}
-\format{A dataframe of 20 observations of 3 variables:
+\format{
+A dataframe of 20 observations of 3 variables:
 
 \code{dhs_gps_data_format}: A dataframe of GPS data descriptions.
 \itemize{
       \item{"Name"}
       \item{"Type"}
       \item{"Description"}
-      }}
+      }
+}
 \usage{
 data(dhs_gps_data_format)
 }

--- a/man/model_datasets.Rd
+++ b/man/model_datasets.Rd
@@ -4,7 +4,8 @@
 \name{model_datasets}
 \alias{model_datasets}
 \title{DHS model datasets}
-\format{A dataframe of 36 observations of 14 variables:
+\format{
+A dataframe of 36 observations of 14 variables:
 
 \code{model_datasets}: A dataframe of model datasets
 \itemize{
@@ -22,7 +23,8 @@
       \item{"FileName"}
       \item{"CountryName"}
       \item{"URLS"}
-      }}
+      }
+}
 \usage{
 data(model_datasets)
 }

--- a/tests/testthat/test_downloads.R
+++ b/tests/testthat/test_downloads.R
@@ -27,7 +27,7 @@ test_that("available surveys and download work", {
   )
 
   # check handle for dataset you don't have permission for
-  downloads <- cli$get_datasets("CDGC61FL.ZIP")
+  expect_message(downloads <- cli$get_datasets("CDGC61FL.ZIP"), "not available")
 
   # check dta foreign only
   downloads <- cli$get_datasets(

--- a/tests/testthat/test_extraction.R
+++ b/tests/testthat/test_extraction.R
@@ -38,7 +38,7 @@ test_that("query codes having downloaded surveys", {
     search_terms = c("fever|test")
   )
 
-  # check the essetial temrs option
+  # check the essetial terms option
   quest <- cli$survey_questions(
     dataset_filenames = "AOBR62DT.ZIP",
     search_terms = c("fever|test"),


### PR DESCRIPTION
Remove `"dhs_dataset"` class from the downloaded datasets. This creates an error in dplyr v1.0 and is not used anywhere else.

Cached datasets will need to be redownloaded after updating the _rdhs_ package

This fixes #105.

Thanks,
Jeff
