### PR TITLE
reference rdhs::model_datasets internally

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rdhs
 Type: Package
 Title: API Client and Dataset Management for the Demographic and Health Survey (DHS) Data
-Version: 0.7.2
+Version: 0.7.3
 Authors@R: 
     c(person(given = "OJ",
              family = "Watson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## rdhs 0.7.3
+
+* Reference internal access to `model_datasets` with `rdhs::model_datasets` to avoid errors if `rdhs` namespace is not loaded.
+
 ## rdhs 0.7.2
 
 * `available_datasets` patch (#115)

--- a/R/client.R
+++ b/R/client.R
@@ -694,7 +694,7 @@ R6_client_dhs <- R6::R6Class(
 
       # are the questions relating to the model datasets
       if (all(substr(unique(questions$dataset_filename), 1, 2) == "zz")) {
-        datasets <- model_datasets
+        datasets <- rdhs::model_datasets
       } else {
         datasets <- self$available_datasets()
       }
@@ -749,7 +749,7 @@ R6_client_dhs <- R6::R6Class(
 
       # grab these now
       filenames <- dhs_datasets(client = self)$FileName
-      filenames <- c(filenames, model_datasets$FileName)
+      filenames <- c(filenames, rdhs::model_datasets$FileName)
 
       # get vars from dataset_paths
       if (!is.null(dataset_paths)) {
@@ -884,22 +884,22 @@ R6_client_dhs <- R6::R6Class(
       }
 
       # ammend our model_datasets first
-      model_datasets <- create_new_filenames(model_datasets)
+      model_datasets_ammend <- create_new_filenames(rdhs::model_datasets)
 
       # if they have only asked for model datasets then return those
-      if (all(filenames %in% model_datasets[[nm_type]])){
-        return(model_datasets[match(filenames, model_datasets[[nm_type]]), ])
+      if (all(filenames %in% model_datasets_ammend[[nm_type]])){
+        return(model_datasets_ammend[match(filenames, model_datasets_ammend[[nm_type]]), ])
       }
 
       # fetch which datasets you can download from your login
       avs <- self$available_datasets()
       avs <- create_new_filenames(avs)
-      avs <- rbind(avs, model_datasets)
+      avs <- rbind(avs, model_datasets_ammend)
 
       # fetch all the datasets so we can catch for the India matches by
       # using the country code catch
       datasets <- dhs_datasets(client = self)
-      datasets <-  rbind(datasets, model_datasets[, -c(14:15)])
+      datasets <-  rbind(datasets, model_datasets_ammend[, -c(14:15)])
 
       # create new filename argument that takes into account the india
       # difficiulties where needed

--- a/R/ui.R
+++ b/R/ui.R
@@ -208,7 +208,7 @@ get_available_datasets <- function(clear_cache = FALSE) {
 
   client <- check_for_client()
   avs <- client$available_datasets(clear_cache)
-  return(rbind(avs, model_datasets))
+  return(rbind(avs, rdhs::model_datasets))
 }
 
 #' Extract Data


### PR DESCRIPTION
## Description
If `rdhs` is not loaded in the global namespace, then `create_new_filenames()` throws an error:

```
Error in strsplit(data$FileName, ".", fixed = TRUE) : 
  object 'model_datasets' not found
> traceback()
10: strsplit(data$FileName, ".", fixed = TRUE)
9: lapply(., function(x) x[1])
8: unlist(.)
7: strsplit(data$FileName, ".", fixed = TRUE) %>% lapply(function(x) x[1]) %>% 
       unlist()
6: create_new_filenames(model_datasets)
5: private$check_available_datasets(dataset_filenames, download_option, 
       reformat)
4: client$get_datasets(dataset_filenames, download_option = download_option, 
       reformat = reformat, all_lower = all_lower, output_dir_root = output_dir_root, 
       clear_cache = clear_cache, ...)
3: rdhs::get_datasets(hrd)
```

This patch references `model_datasets` with `rdhs::model_datasets` to fix this.
