### PR TITLE
v0.7.6 fix for authentication error of downloads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rdhs
 Type: Package
 Title: API Client and Dataset Management for the Demographic and Health Survey (DHS) Data
-Version: 0.7.5
+Version: 0.7.6
 Authors@R: 
     c(person(given = "OJ",
              family = "Watson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## rdhs 0.7.6
+
+* Authentication patch for downloading datasets (#120) 
+
 ## rdhs 0.7.5
 
 * `download_boundaries` patch (#138) for pause when downloading survey boundaries. Set default sleep to 5 seconds to avoid timeout.

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -290,15 +290,9 @@ download_datasets <- function(config,
     # if it's not the right size and first time we've tried then log in
     if (file.size(tf) != desired_dataset$FileSize[1] & attempts == 3) {
 
-      # login
-      values <- authenticate_dhs(config)
-      project_number <- values$proj_id
+      # do updated authentication procedure
+      auth_downloads(config)
 
-      # access the download-datasets page
-      z <- httr::POST(
-        "https://dhsprogram.com/data/dataset_admin/download-datasets.cfm",
-        body = list(proj_id = project_number)
-      )
     } else if (file.size(tf) == desired_dataset$FileSize[1]) {
       file_size_check <- FALSE
       attempts <- 0
@@ -530,3 +524,31 @@ authenticate_dhs <- function(config) {
 
   return(res)
 }
+
+#' @noRd
+auth_downloads <- function(config){
+
+  # authenticate
+  values <- authenticate_dhs(config)
+
+  # grab project number here
+  project_number <- values$proj_id
+
+  # Create post request for the download manager
+  values <- list(
+    Proj_ID = project_number,
+    action = "getdatasets"
+  )
+
+  # re-access the download-datasets page
+  z <- httr::POST(
+    "https://dhsprogram.com/data/dataset_admin/download-datasets.cfm",
+    body = list(proj_id = project_number)
+  )
+
+  # Head to download page
+  z <- httr::POST("https://dhsprogram.com/data/dataset_admin/index.cfm",
+                  body = values)
+
+}
+

--- a/tests/testthat/test_authentication.R
+++ b/tests/testthat/test_authentication.R
@@ -44,3 +44,13 @@ test_that("available_surveys works", {
 
   unlink(cli$get_root())
 })
+
+test_that("auth_downloads works", {
+  testthat::skip_on_cran()
+  skip_if_no_auth()
+
+  config <- read_rdhs_config_file("rdhs.json")
+  z <- auth_downloads(config)
+
+  expect_true(z$request$fields$action == "getdatasets")
+})


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Additional authentication step before downloading datasets to provide fix on certain systems.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

#120

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

Previously following error:

```
et2 <- get_datasets("ETCR71FL.ZIP", clear_cache = FALSE)  
Downloading: 
Ethiopia 2016 DHS Couples' Recode Flat ASCII data (.dat) [ETCR71FL.ZIP]
Logging into DHS website...
Error in unzip(tf, list = TRUE) :
zip file '/tmp/RtmpaJOmOD/file83533c1a4bca' cannot be opened
```

Only way previously to fix was with `clear_cache = TRUE`. The authentication step needed had changed on DHS website, but has now been identified and moved into `auth_downloads` internal within `get_datasets`