### PR TITLE
parse_dfc(): convert dictionary to UTF-8 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rdhs
 Type: Package
 Title: API Client and Dataset Management for the Demographic and Health Survey (DHS) Data
-Version: 0.8.0.9000
+Version: 0.8.1
 Authors@R: 
     c(person(given = "OJ",
              family = "Watson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # rdhs (development version)
 
+## rdhs 0.8.1
+
+* Convert DHS dataset flat file data dictionaries to UTF-8. This addresses 
+  parsing issue that arose following R 4.3.0 (#146; https://github.com/ropensci/rdhs/issues/146#issuecomment-1781243144). In doing so, it addresses a longstanding annoyance of
+  accents in variable and value labels not being parsed correctly.
+  
 ## rdhs 0.8.0
 
 * Update for deprecation of spatial infrastructure (#145).

--- a/R/read_dhs_flat.R
+++ b/R/read_dhs_flat.R
@@ -35,7 +35,10 @@ parse_dcf <- function(dcf, all_lower=TRUE) {
 
   items <- lapply(item.idx, function(idx) paste(dcf[idx], collapse = "\n"))
   is_utf8 <- vapply(items, validUTF8, logical(1))
-  items[!is_utf8] <- lapply(items[!is_utf8], iconv, from = "latin2", to = "UTF-8")
+
+  items[!is_utf8] <- lapply(
+    items[!is_utf8], FUN = iconv, from = "latin2", to = "UTF-8"
+  )
 
   dcf <- data.frame(
     name = tolower(sub(".*?\nName=([^\n]*)\n.*", "\\1", items)),
@@ -194,7 +197,7 @@ parse_sps <- function(sps, all_lower=TRUE) {
 
   ## remove duplicate values from labels
   values <- lapply(values, function(x) x[!duplicated(x)])
-  
+
   dct$labels <- values[dct$name]
 
   return(dct)

--- a/R/read_dhs_flat.R
+++ b/R/read_dhs_flat.R
@@ -34,6 +34,8 @@ parse_dcf <- function(dcf, all_lower=TRUE) {
   item.idx <- Map("+", item.start - 1L, lapply(item.len, seq_len))
 
   items <- lapply(item.idx, function(idx) paste(dcf[idx], collapse = "\n"))
+  is_utf8 <- vapply(items, validUTF8, logical(1))
+  items[!is_utf8] <- lapply(items[!is_utf8], iconv, from = "latin2", to = "UTF-8")
 
   dcf <- data.frame(
     name = tolower(sub(".*?\nName=([^\n]*)\n.*", "\\1", items)),

--- a/tests/testthat/test_downloads.R
+++ b/tests/testthat/test_downloads.R
@@ -222,3 +222,17 @@ test_that("Geospatial coviarates", {
 
 })
 
+test_that("UTF-8 Reading Correctly", {
+  testthat::skip_on_cran()
+  skip_if_no_auth()
+
+  cli <- new_rand_client()
+
+  # check gc file
+  downloads <- cli$get_datasets("AOPR51FL.zip")
+  d <- readRDS(downloads$AOPR51FL)
+
+  expect_true(grepl("é", names(attr(d$hv024,"labels")[1])))
+
+})
+


### PR DESCRIPTION
## Description
This converts non UTF-8 strings to UTF-8 to address R 4.3.0 update: `Regular expression functions now check more thoroughly whether their inputs are valid strings (in their encoding, e.g. in UTF-8).`

In doing so, it addresses a longstanding annoyance of accents in variable and value labels not being parsed correctly.

Solution identified thanks to: https://stackoverflow.com/questions/76680882/unable-to-translate-to-a-wide-string

* The code checks for strings that are not valid UTF-8 and only converts those using `iconv()`. The reason is because applying `iconv()` to a string that is already UTF-8 will mess it up. I'm not sure if this is needed, but it seems conservative to implement this way.
* It assumes that any non-UTF-8 strings are `"latin2"` encoding. This does the right thing in the handful of cases I've tested on. Not sure if there is a better approach here.

## Related Issue
fix #146 

## Example
See #146 for examples.

With `rdhs 0.8.0`:
```
> get_datasets("AOPR51FL")

Downloading: 
Angola 2006 MIS Household Member Recode Flat ASCII data (.dat) [AOPR51FL.zip]
Logging into DHS website...
Error in sub(".*?\nName=([^\n]*)\n.*", "\\1", items) : 
  input string 26 is invalid
In addition: Warning message:
In sub(".*?\nName=([^\n]*)\n.*", "\\1", items) :
  unable to translate '[Item]
Label=Sample domain
Name=HV023
Start=85
Len=2

[ValueSet]
Label=Sample domain
Name=HV023_VS1
Value=1;Stable mesoendemic (Zaire, Luanda, Bengo, Benguela, K. Sul, Huambo, Bi<e9>)
Value=2;Hyperendemic (Cabinda, Uige, K. Norte, Malange, L. Norte, L....' to a wide string
> 
```

With patched `rdhs_0.8.1`:
```
> get_datasets("AOPR51FL")
Downloading: 
Angola 2006 MIS Household Member Recode Flat ASCII data (.dat) [AOPR51FL.zip]
Dataset download finished
$AOPR51FL
[1] "~/Downloads/rdhs_tmp//datasets/AOPR51FL.rds"
```

## Notes:

* I'm not sure how to test this; requires a flat file with non-ASCII characters.
* It's possible that this line would more appropriately use `iconv(..., from = "latin2", ...)` rather than `iconv(..., sub = "")`.  https://github.com/ropensci/rdhs/blob/4f0124d74f17b572c272f0ff3b9e2b152a4f6502/R/read_dhs_flat.R#L112 I can't remember exactly what conversion addresses and I don't know any test examples off the top of my head; these same ones giving issue with `parse_dcf()` are a good bet.
* There might be other places that would also benefit from UTF-8 conversion.