### PR TITLE
replace iotools with vroom **WIP**

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rdhs
 Type: Package
 Title: API Client and Dataset Management for the Demographic and Health Survey (DHS) Data
-Version: 0.8.2
+Version: 0.8.3
 Authors@R: 
     c(person(given = "OJ",
              family = "Watson",
@@ -43,10 +43,10 @@ Imports:
     qdapRegex,
     getPass,
     haven,
-    iotools,
     sf,
     cli, 
-    rlang
+    rlang,
+    vroom
 Suggests:
     testthat,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,15 @@
 # rdhs (development version)
 
+## rdhs 0.8.3
+
+* Internal change to `read_dhs_flat()` to reduce memory usage (`for` loop instead of `Map()`). 
+  Reduces risk of `Error: vector memory exhausted` when parsing large dataset.
+* Replace iotools::input.file() with vroom::vroom_fwf().
+
 ## rdhs 0.8.2
 
 * Spatial boundaries will be cached using the DHS client  (#122)
+
 
 ## rdhs 0.8.1
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,7 +28,7 @@ rbind_list_base <- function(x) {
 #'
 unzip_special <- function(zipfile, files = NULL, overwrite = TRUE,
                           junkpaths = FALSE, exdir = ".", unzip = "internal",
-                          setTimes = FALSE){
+                          setTimes = FALSE) {
 
   if (max(unzip(zipfile, list = TRUE)$Length) > 4e9) {
     unzip_file <- Sys.which("unzip")


### PR DESCRIPTION
In `read_dhs_flat()`, replace `iotools::input.file()` with `vroom::vroom()` for reading fixed-width text files.

`vroom::vroom` is _much faster_ and memory efficient. Makes all parsing faster and improves ability to read very large datasets without exhausting system memory (i.e. India DHS surveys).

Also replaces `Map()` with `for()` loop when assigning variable labels to avoid full dataset copy in memory.

**Work in progress**
------
This PR works, but two remaining things to do:
- [ ] `vroom::vroom()` is pretty chatty and throws lots of messages / warnings. Probably want to silence some of these.
- [ ] Run a systematic download of all datasets to ensure no edge cases or unexpected issues.